### PR TITLE
control if all rank should log or not with env var

### DIFF
--- a/src/zeroband/utils/logging.py
+++ b/src/zeroband/utils/logging.py
@@ -6,6 +6,12 @@ from zeroband.utils.world_info import get_world_info
 logger = None
 
 
+"""
+ZERO_BAND_LOG_LEVEL=DEBUG allow to control the log level for all ranks
+ZERO_BAND_LOG_ALL_RANK=true allow to control if all ranks should log or only the local rank 0
+"""
+
+
 class CustomFormatter(logging.Formatter):
     def __init__(self, local_rank: int):
         super().__init__()
@@ -26,11 +32,15 @@ def get_logger():
     world_info = get_world_info()
     logger = logging.getLogger(__name__)
 
+    log_level = os.getenv("ZERO_BAND_LOG_LEVEL", "INFO")
+
     if world_info.local_rank == 0:
-        log_level = os.getenv("ZERO_BAND_LOG_LEVEL", "INFO")
         logger.setLevel(level=getattr(logging, log_level, logging.INFO))
     else:
-        logger.setLevel(level=logging.CRITICAL)  # Disable logging for non-zero ranks
+        if os.getenv("ZERO_BAND_LOG_ALL_RANK", "false").lower() == "true":
+            logger.setLevel(level=getattr(logging, log_level, logging.INFO))
+        else:
+            logger.setLevel(level=logging.CRITICAL)  # Disable logging for non-zero ranks
 
     handler = logging.StreamHandler()
     handler.setFormatter(CustomFormatter(world_info.local_rank))


### PR DESCRIPTION
by default only local rank 0 log to stdout. This pr allows to control this behavior and allow all ranks to log. Useful for debugging purpose

ZERO_BAND_LOG_ALL_RANK=true allow to control if all ranks should log or only the local rank 0