### PR TITLE
WIP: fix diloco with shard grap op

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ uv run ...
 To check that everything is working you can do
 
 ```bash
-ZERO_BAND_LOG_LEVEL=DEBUG torchrun  --nproc_per_node=2 src/zeroband/train.py @configs/debug/debug.toml
+ZERO_BAND_LOG_LEVEL=DEBUG torchrun  --nproc_per_node=2 src/zeroband/train.py @configs/debug/normal.toml
 ```
 
 ## run diloco

--- a/configs/debug/diloco.toml
+++ b/configs/debug/diloco.toml
@@ -9,11 +9,11 @@ sharding_strategy = "FULL_SHARD"
 [optim]
 batch_size = 16
 warmup_steps = 10
-total_steps = 10
+total_steps = 4
 
 [data]
 fake = true
 
 [diloco]
-inner_steps = 5
+inner_steps = 2
 

--- a/configs/debug/normal.toml
+++ b/configs/debug/normal.toml
@@ -9,7 +9,7 @@ sharding_strategy = "SHARD_GRAD_OP"
 [optim]
 batch_size = 16
 warmup_steps = 10
-total_steps = 10
+total_steps = 4
 
 [data]
 fake = true

--- a/scripts/simulate_multi_node.sh
+++ b/scripts/simulate_multi_node.sh
@@ -2,7 +2,7 @@
 
 #
 # simulate multi nodes on one gpu. start N torchrun on X gpu locally.
-# example how to run ./scripts/simulate_multi_node.sh 2 1  src/zeroband/train.py @configs/debug/debug.toml
+# example how to run ./scripts/simulate_multi_node.sh 2 1  src/zeroband/train.py @configs/debug/normal.toml
 
 # Function to get CUDA devices based on the number of GPUs and index
 function get_cuda_devices() {

--- a/src/zeroband/diloco.py
+++ b/src/zeroband/diloco.py
@@ -75,19 +75,16 @@ class Diloco:
         self._logger = get_logger()
         self.world_info = get_world_info()
 
-        self.need_to_offload = (
-            self.fsdp_sharding_strategy == ShardingStrategy.FULL_SHARD or self.world_info.local_rank == 0
-        )
-        # if we are not in fully sharded mode only the local rank 0 will have the model on cpu
-        if self.need_to_offload:
-            self._init_offloaded_optimizer(model=model)
-        else:
-            self.outer_optimizer = None
-            self.cpu_model = None
+        if self.fsdp_sharding_strategy not in [ShardingStrategy.FULL_SHARD, ShardingStrategy.SHARD_GRAD_OP]:
+            raise ValueError("Diloco only support FULL_SHARD and SHARD_GRAD_OP")
+
+        self._init_offloaded_optimizer(model=model)
 
     def _init_offloaded_optimizer(self, model):
-        self.cpu_model = self.get_offloaded_param(model)
-        self.outer_optimizer = torch.optim.SGD(self.cpu_model, lr=self.config.outer_lr, momentum=0.9, nesterov=True)
+        self.param_list_cpu = self.get_offloaded_param(model)
+        self.outer_optimizer = torch.optim.SGD(
+            self.param_list_cpu, lr=self.config.outer_lr, momentum=0.9, nesterov=True
+        )
         self._logger.debug("offload model to cpu")
 
     def sync_pseudo_gradient(self, model: nn.Module):
@@ -96,7 +93,7 @@ class Diloco:
         """
         if self.need_to_offload:
             self._logger.debug("sync pseudo gradient")
-            for param_offloaded, param in zip(self.cpu_model, model.parameters()):
+            for param_offloaded, param in zip(self.param_list_cpu, model.parameters()):
                 # todo check how to handle the SHARD_GRAD_OP strategy where the weight are replicated across the local devices
                 param_offloaded.grad = param_offloaded.data - param.data.to(param_offloaded.device)
 
@@ -112,28 +109,16 @@ class Diloco:
         Sync the inner model from the global process group to the local process group
         """
 
-        if self.fsdp_sharding_strategy == ShardingStrategy.FULL_SHARD:
-            # here each rank has a shard of the model in memory so all rank do the sync
-            self._logger.debug("sync inner model")
-            for param_offloaded, param in zip(self.cpu_model, model.parameters()):
-                param.data = param_offloaded.data.to("cuda")  # todo: use copy_ here
-
-        elif self.fsdp_sharding_strategy in [ShardingStrategy.SHARD_GRAD_OP, ShardingStrategy.NO_SHARD]:
-            self._logger.debug("sync inner model")
-            # in shard_grad_op mode, only the local rank 0 has the model in cpu
-            # we first copy the model to the gpu 0 and then broadcast it to the other gpu as
-            # gpu to gpu is faster than cpu to gpu with nvlink
-            if self.world_info.local_rank == 0:
-                for param_offloaded, param in zip(self.cpu_model, model.parameters()):
-                    # todo: we can probably overlap both comm here
-                    param.data = param_offloaded.data.to("cuda")
-                    dist.broadcast(tensor=param.data, src=0, group=self.elastic_device_mesh.local_pg)
+        self._logger.debug("sync inner model")
+        for param_offloaded, param in zip(self.param_list_cpu, model.parameters()):
+            param.data = param_offloaded.data.to("cuda")  # todo: use copy_ here
 
     def get_offloaded_param(self, model: nn.Module) -> list[nn.Parameter]:
         """
         Offload the model parameters to cpu
         """
         offloaded_params = []
+
         for param in model.parameters():
             if param.requires_grad:
                 offloaded_param = param.data.detach().clone().to("cpu")

--- a/tests/test_torchrun/test_train.py
+++ b/tests/test_torchrun/test_train.py
@@ -28,7 +28,7 @@ def gpus_to_use(num_nodes, num_gpu, rank):
     return ",".join(map(str, range(rank * num_gpu, (rank + 1) * num_gpu)))
 
 
-def _test_multi_gpu(num_gpus, config, diloco: bool):
+def _test_multi_gpu(num_gpus, config):
     num_nodes, num_gpu = num_gpus[0], num_gpus[1]
 
     processes = []
@@ -56,10 +56,10 @@ def _test_multi_gpu(num_gpus, config, diloco: bool):
 
 @pytest.mark.parametrize("num_gpus", [[1, 1], [2, 1], [1, 2]])
 def test_multi_gpu(num_gpus):
-    _test_multi_gpu(num_gpus, "debug/debug.toml", diloco=False)
+    _test_multi_gpu(num_gpus, "debug/debug.toml")
 
 
 @pytest.mark.parametrize("num_gpus", [[1, 2], [2, 2]])
 def test_multi_gpu_diloco(num_gpus):
     # we don't test 1,1 and 2,1 because 1 solo gpu failed with fsdp
-    _test_multi_gpu(num_gpus, "debug/diloco.toml", diloco=True)
+    _test_multi_gpu(num_gpus, "debug/diloco.toml")

--- a/tests/test_torchrun/test_train.py
+++ b/tests/test_torchrun/test_train.py
@@ -66,7 +66,7 @@ def test_multi_gpu_diloco(num_gpus):
     _test_multi_gpu(num_gpus, "debug/diloco.toml")
 
 
-@pytest.mark.parametrize("strategy", ["SHARD_GRAD_OP", "NO_SHARD"])
+@pytest.mark.parametrize("strategy", ["SHARD_GRAD_OP"])
 def test_multi_gpu_diloco_non_full_shard(strategy):
     # we don't test 1,1 and 2,1 because 1 solo gpu failed with fsdp
     num_gpus = [2, 2]


### PR DESCRIPTION
This PR fixes diloco with shard grap op.

What it does is to handle shared grap op the same way a fully shared is. It, unfortunately, has to be the case for now because FSPD handles SHARD_GRAD_OP like normal full shard expect it does not release the weight after the first all gather. Meaning that the offload pre all gather is not working with shard grap op.