### PR TITLE
fix: use rolling window for mfu calculation

### DIFF
--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -164,7 +164,7 @@ def train(config: Config):
 
         for inner_step in range(num_inner_steps):
             loss_batch = 0
-            beginning_step_time = time.time()
+            beginning_step_time = time.perf_counter()
 
             for grad_acc_step in range(gradient_accumulation_steps):
                 is_accumulating = grad_acc_step < gradient_accumulation_steps - 1
@@ -197,7 +197,7 @@ def train(config: Config):
             # syncing loss across all data parallel rank
             # todo(sami): when using diloco make sure that the loss is computed only on local world
 
-            time_taken = time.time() - beginning_step_time
+            time_taken = time.perf_counter() - beginning_step_time
             tokens_per_second = config.data.seq_length * config.optim.batch_size / time_taken
 
             mfu = 100 * num_flop_per_token * tokens_per_second / gpu_peak_flops / world_info.local_world_size


### PR DESCRIPTION
this pr fix the weird unstable mfu. It use a rolling average of tokens_per_second. The old implementation that was measuring the time per steps was unstable, lead to weird mfu (>100 with grad_acc=1). 

[h100 sxm]
1b with 4 gpus : 48.70
1b with 8 gpus: 47.68