### PR TITLE
[fix] set 5m timeot for global tcp store

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ HF_HUB_ETAG_TIMEOUT=500
 | `GLOBAL_PORT`         | Port number of the global store.                 | `None` |
 | `GLOBAL_WORLD_SIZE`   | The size of the global process group.            | `1` |
 | `GLOBAL_RANK`         | Rank of the process in the global process group. | `0` |
+| `ZERO_BAND_GLOBAL_STORE_TIMEOUT_SECONDS` | Number of seconds before the global store operations timeout | `300` |

--- a/src/zeroband/comms.py
+++ b/src/zeroband/comms.py
@@ -1,3 +1,4 @@
+import os
 from torch.distributed.device_mesh import init_device_mesh
 from zeroband.utils.world_info import get_world_info
 from zeroband.utils.logging import get_logger
@@ -8,7 +9,7 @@ from typing import List, Tuple, Optional
 from torch.testing._internal.distributed.fake_pg import FakeProcessGroup
 
 
-TCPSTORE_TIMEOUT = timedelta(seconds=10)
+TCPSTORE_TIMEOUT = timedelta(seconds=int(os.getenv("ZERO_BAND_GLOBAL_STORE_TIMEOUT_SECONDS", "300")))
 MAX_JOINERS = 100  # Maximum number of nodes that can join in a single reinit
 MAX_LEAVERS = 100  # Maximum number of nodes that can leave in a single reinit
 


### PR DESCRIPTION
The previous timeout was just 10 seconds. Extending to 5 minutes makes sense.

Also allowed it to be set by env var