### PR TITLE
[fix] fail when diloco is used with global pg size of 1

### DIFF
--- a/src/zeroband/diloco.py
+++ b/src/zeroband/diloco.py
@@ -55,6 +55,9 @@ class Diloco:
         if self.fsdp_sharding_strategy not in [ShardingStrategy.FULL_SHARD, ShardingStrategy.SHARD_GRAD_OP]:
             raise ValueError("Diloco only support FULL_SHARD and SHARD_GRAD_OP")
 
+        if self.world_info.global_world_size < 1:
+            raise ValueError("Diloco requires a global world size of at least 1")
+
         self._init_offloaded_optimizer(model=model)
 
     def _init_offloaded_optimizer(self, model):

--- a/src/zeroband/utils/world_info.py
+++ b/src/zeroband/utils/world_info.py
@@ -21,7 +21,7 @@ class WorldInfo:
         self.global_unique_id = os.environ.get("GLOBAL_UNIQUE_ID", None)
         self.global_addr = os.environ.get("GLOBAL_ADDR", None)
         self.global_port = int(os.environ.get("GLOBAL_PORT")) if "GLOBAL_PORT" in os.environ else None
-        self.global_world_size = int(os.environ.get("GLOBAL_WORLD_SIZE", 1))
+        self.global_world_size = int(os.environ.get("GLOBAL_WORLD_SIZE", 0))
         self.global_rank = int(os.environ.get("GLOBAL_RANK", 0))
 
     def __repr__(self):


### PR DESCRIPTION
Without this, running the wrong simulate_multi_node shell script doesnt lead to errors but instead creates diloco workers that dont communicate.

This PR causes the training to error in this case as you would never want to do this.