### PR TITLE
log all reduce time diloco

### DIFF
--- a/src/zeroband/diloco.py
+++ b/src/zeroband/diloco.py
@@ -1,3 +1,4 @@
+import time
 from pydantic_config import BaseConfig
 import torch
 from torch import nn
@@ -106,7 +107,10 @@ class Diloco:
         """
         Step the optimizer
         """
+        time_start = time.perf_counter()
         self.sync_pseudo_gradient(model)
+        self._logger.info(f"all reduce pseudo gradient in: {time.perf_counter() - time_start} seconds")
+
         if self.outer_optimizer is not None:
             self.outer_optimizer.step()
             self.outer_optimizer.zero_grad()  # todo(sami): check if we can remove this

--- a/src/zeroband/utils/__init__.py
+++ b/src/zeroband/utils/__init__.py
@@ -90,7 +90,7 @@ class PerfCounter:
     def get_tokens_per_second(self) -> float | None:
         if len(self.tokens) < 2:
             return None
-        return sum(self.tokens) / (self.times[-1] - self.times[0])
+        return sum(self.tokens[1:]) / (self.times[-1] - self.times[0])
 
 
 TENSOR_SIG_SAMPLE_SIZE = 100


### PR DESCRIPTION
this pr add two things

* log all reduce time
* overall mfu using diloco and taking into consideration the all reduce

it reverts the window count for mfu. The simple work well for 1B and 7b Model, still a bit weird with 150M.


here 1b mfu
```
17:45:05 [INFO] [Rank 0] step: 1, loss: 10.8585, tokens_per_second: 49722.00, mfu: 4.02
17:45:09 [INFO] [Rank 0] step: 2, loss: 10.8607, tokens_per_second: 628145.53, mfu: 50.78
17:45:12 [INFO] [Rank 0] step: 3, loss: 10.8618, tokens_per_second: 624814.93, mfu: 50.51
17:45:16 [INFO] [Rank 0] step: 4, loss: 10.8560, tokens_per_second: 625376.60, mfu: 50.55
17:45:20 [INFO] [Rank 0] step: 5, loss: 10.8539, tokens_per_second: 627185.73, mfu: 50.70
17:45:23 [INFO] [Rank 0] step: 6, loss: 10.8527, tokens_per_second: 625519.12, mfu: 50.56
```
