### PR TITLE
Faster All-Reduce

### DIFF
--- a/src/zeroband/C/collectives.py
+++ b/src/zeroband/C/collectives.py
@@ -1,0 +1,26 @@
+from typing import Optional, Callable
+import torch
+import torch.distributed as dist
+from torch.utils import cpp_extension
+from pathlib import Path
+
+INCLUDES = [str(Path(__file__).parent / "csrc")]
+COLLECTIVES_CSRC_PATH = Path(__file__).parent / "csrc" / "collectives.cpp"
+
+collectives_ops = cpp_extension.load(
+    name="collectives",
+    sources=[COLLECTIVES_CSRC_PATH],
+    extra_cflags=["-O3"],
+    verbose=True,
+    extra_include_paths=INCLUDES,
+)
+
+
+def ring_allreduce(
+    tensor: torch.Tensor,
+    op: dist.ReduceOp = dist.ReduceOp.SUM,
+    group: Optional[dist.ProcessGroup] = None,
+    transfer_dtype: Optional[torch.dtype] = None,
+    quantization_func: Optional[Callable] = None,
+) -> None:
+    collectives_ops.ring_allreduce(tensor, op, group)

--- a/src/zeroband/C/collectives.py
+++ b/src/zeroband/C/collectives.py
@@ -11,7 +11,7 @@ collectives_ops = cpp_extension.load(
     name="collectives",
     sources=[COLLECTIVES_CSRC_PATH],
     extra_cflags=["-O3"],
-    verbose=True,
+    verbose=False,
     extra_include_paths=INCLUDES,
 )
 
@@ -23,4 +23,6 @@ def ring_allreduce(
     transfer_dtype: Optional[torch.dtype] = None,
     quantization_func: Optional[Callable] = None,
 ) -> None:
+    if group is None:
+        group = dist.distributed_c10d._get_default_group()
     collectives_ops.ring_allreduce(tensor, op, group)

--- a/src/zeroband/C/csrc/collectives.cpp
+++ b/src/zeroband/C/csrc/collectives.cpp
@@ -152,6 +152,7 @@ void ring_allreduce(
         }
     }
 
+    // TODO: Interleave these with the previous loop?
     if (op == c10d::ReduceOp::AVG) {
         for (int i = 0; i < BUFFER_COUNT; ++i) {
             chunks[i + rank * BUFFER_COUNT].div_(world_size);
@@ -196,9 +197,7 @@ void ring_allreduce(
             recv_work[step % BUFFER_COUNT]->wait();
             send_lookup_work[step % BUFFER_COUNT]->wait();
             recv_lookup_work[step % BUFFER_COUNT]->wait();
-            //auto a = recv_lookup_buffer[step % BUFFER_COUNT].index({recv_buffer[step % BUFFER_COUNT].to(torch::kLong)});
-            //chunks[send_chunk].copy_(a);
-            //chunks[send_chunk].copy_(recv_lookup_buffer[step % BUFFER_COUNT].index({recv_buffer[step % BUFFER_COUNT].to(torch::kLong)}).to(tensor.dtype()));
+
             auto& chunk = chunks[send_chunk];
             auto& lookup = recv_lookup_buffer[step % BUFFER_COUNT];
             auto& indices = recv_buffer[step % BUFFER_COUNT];

--- a/src/zeroband/C/csrc/collectives.cpp
+++ b/src/zeroband/C/csrc/collectives.cpp
@@ -1,0 +1,144 @@
+#include <torch/torch.h>
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <compression.cpp>
+
+constexpr int BUFFER_COUNT = 2;
+
+void ring_allreduce(
+    torch::Tensor& tensor,
+    c10d::ReduceOp op,
+    c10d::ProcessGroup* group
+) {
+    TORCH_CHECK(group != nullptr, "Group must be provided");
+    TORCH_CHECK(op == c10d::ReduceOp::SUM || op == c10d::ReduceOp::AVG, "Unsupported reduce operation. Only SUM and AVG are supported.");
+
+    int world_size = group->getSize();
+    int rank = group->getRank();
+
+    // Divide the tensor into chunks
+    auto flat_tensor = tensor.view({tensor.numel()});
+    std::vector<torch::Tensor> chunks = flat_tensor.chunk(world_size * BUFFER_COUNT);
+
+    TORCH_CHECK(flat_tensor.size(0) % (world_size * BUFFER_COUNT) == 0, "Tensor size must be divisible by world size");
+
+    // Temporary buffers for transferring data
+    int num_buffers = BUFFER_COUNT * world_size;
+    std::vector<torch::Tensor> recv_buffer;
+    std::vector<torch::Tensor> send_buffer;
+    std::vector<torch::Tensor> send_lookup_buffer;
+    std::vector<torch::Tensor> recv_lookup_buffer;
+    std::vector<c10::intrusive_ptr<c10d::Work>> send_lookup_work(BUFFER_COUNT);
+    std::vector<c10::intrusive_ptr<c10d::Work>> recv_lookup_work(BUFFER_COUNT);
+    std::vector<c10::intrusive_ptr<c10d::Work>> send_work(BUFFER_COUNT);
+    std::vector<c10::intrusive_ptr<c10d::Work>> recv_work(BUFFER_COUNT);
+
+    for (int i = 0; i < BUFFER_COUNT; ++i) {
+        recv_buffer.push_back(torch::empty_like(chunks[0], torch::kUInt8));
+        send_buffer.push_back(torch::Tensor());
+        send_lookup_buffer.push_back(torch::Tensor());
+        recv_lookup_buffer.push_back(torch::empty({256}, chunks[0].options()));
+    }
+
+    // Send and receive ranks
+    int send_rank = (rank + 1) % world_size;
+    int recv_rank = (rank - 1 + world_size) % world_size;
+
+    // Reduce-scatter loop
+    for (int step = 1; step <= world_size * BUFFER_COUNT; ++step) {
+        int send_chunk = (rank * BUFFER_COUNT - step + num_buffers) % num_buffers;
+
+        if (send_work[step % BUFFER_COUNT]) {
+            send_work[step % BUFFER_COUNT]->wait();
+            recv_work[step % BUFFER_COUNT]->wait();
+            send_lookup_work[step % BUFFER_COUNT]->wait();
+            recv_lookup_work[step % BUFFER_COUNT]->wait();
+            chunks[send_chunk].add_(recv_lookup_buffer[step % BUFFER_COUNT].index({recv_buffer[step % BUFFER_COUNT].to(torch::kLong)}));
+        }
+
+        if (step <= (world_size - 1) * BUFFER_COUNT) {
+            // Quantize and send
+            std::tie(send_buffer[step % BUFFER_COUNT], send_lookup_buffer[step % BUFFER_COUNT]) = uniform_8bit_quantize(chunks[send_chunk], false);
+
+            std::vector<torch::Tensor> send_tensors = {send_lookup_buffer[step % BUFFER_COUNT]};
+            send_lookup_work[step % BUFFER_COUNT] = group->send(send_tensors, send_rank, step + 1000);
+
+            std::vector<torch::Tensor> recv_tensors = {recv_lookup_buffer[step % BUFFER_COUNT]};
+            recv_lookup_work[step % BUFFER_COUNT] = group->recv(recv_tensors, recv_rank, step + 1000);
+
+            send_tensors = {send_buffer[step % BUFFER_COUNT]};
+            send_work[step % BUFFER_COUNT] = group->send(send_tensors, send_rank, step);
+
+            recv_tensors = {recv_buffer[step % BUFFER_COUNT]};
+            recv_work[step % BUFFER_COUNT] = group->recv(recv_tensors, recv_rank, step);
+        }
+    }
+
+    if (op == c10d::ReduceOp::AVG) {
+        for (int i = 0; i < BUFFER_COUNT; ++i) {
+            chunks[i + rank * BUFFER_COUNT].div_(world_size);
+        }
+    }
+    
+    for (int i = 0; i < BUFFER_COUNT; ++i) {
+        std::tie(send_buffer[0], send_lookup_buffer[0]) = uniform_8bit_quantize(chunks[i + rank * BUFFER_COUNT], true);
+        chunks[i + rank * BUFFER_COUNT].copy_(send_lookup_buffer[0].index({send_buffer[0].to(torch::kLong)}));
+    }
+
+    // Reset buffers for the second phase
+    recv_buffer.clear();
+    send_buffer.clear();
+    send_lookup_buffer.clear();
+    recv_lookup_buffer.clear();
+    for (int i = 0; i < BUFFER_COUNT; ++i) {
+        recv_buffer.push_back(torch::empty_like(chunks[0], torch::kUInt8));
+        send_buffer.push_back(torch::Tensor());
+        send_lookup_buffer.push_back(torch::Tensor());
+        recv_lookup_buffer.push_back(torch::empty({256}, chunks[0].options()));
+    }
+    std::fill(send_work.begin(), send_work.end(), nullptr);
+    std::fill(recv_work.begin(), recv_work.end(), nullptr);
+    std::fill(send_lookup_work.begin(), send_lookup_work.end(), nullptr);
+    std::fill(recv_lookup_work.begin(), recv_lookup_work.end(), nullptr);
+
+    for (int step = 1; step <= world_size * BUFFER_COUNT; ++step) {
+        int send_chunk = (rank * BUFFER_COUNT + BUFFER_COUNT - step + num_buffers) % num_buffers;
+
+        if (send_work[step % BUFFER_COUNT]) {
+            send_work[step % BUFFER_COUNT]->wait();
+            recv_work[step % BUFFER_COUNT]->wait();
+            send_lookup_work[step % BUFFER_COUNT]->wait();
+            recv_lookup_work[step % BUFFER_COUNT]->wait();
+            auto a = recv_lookup_buffer[step % BUFFER_COUNT].index({recv_buffer[step % BUFFER_COUNT].to(torch::kLong)});
+            chunks[send_chunk].copy_(a);
+            //chunks[send_chunk].copy_(recv_lookup_buffer[step % BUFFER_COUNT].index({recv_buffer[step % BUFFER_COUNT].to(torch::kLong)}).to(tensor.dtype()));
+        }
+
+        if (step <= (world_size - 1) * BUFFER_COUNT) {
+            // Quantize and send
+            std::tie(send_buffer[step % BUFFER_COUNT], send_lookup_buffer[step % BUFFER_COUNT]) = uniform_8bit_quantize(chunks[send_chunk], false);
+
+            std::vector<torch::Tensor> send_tensors = {send_lookup_buffer[step % BUFFER_COUNT]};
+            send_lookup_work[step % BUFFER_COUNT] = group->send(send_tensors, send_rank, step + 1000);
+
+            std::vector<torch::Tensor> recv_tensors = {recv_lookup_buffer[step % BUFFER_COUNT]};
+            recv_lookup_work[step % BUFFER_COUNT] = group->recv(recv_tensors, recv_rank, step + 1000);
+
+            send_tensors = {send_buffer[step % BUFFER_COUNT]};
+            send_work[step % BUFFER_COUNT] = group->send(send_tensors, send_rank, step);
+
+            recv_tensors = {recv_buffer[step % BUFFER_COUNT]};
+            recv_work[step % BUFFER_COUNT] = group->recv(recv_tensors, recv_rank, step);
+        }
+    }
+}
+
+PYBIND11_MODULE(collectives, m) {
+    m.def(
+        "ring_allreduce",
+        &ring_allreduce,
+        "Ring allreduce implementation",
+        py::arg("tensor"),
+        py::arg("op"),
+        py::arg("pg")
+    )
+}

--- a/src/zeroband/collectives.py
+++ b/src/zeroband/collectives.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Callable, Optional, TypeAlias
 import torch
 import torch.distributed as dist
+from zeroband.C.collectives import ring_allreduce as ring_allreduce_c
 
 AllReduceFunc: TypeAlias = Callable[
     [torch.Tensor, dist.ReduceOp, Optional[dist.ProcessGroup], Optional[torch.dtype]], None
@@ -180,9 +181,11 @@ def ring_allreduce(
 class AllReduceBackend(Enum):
     GLOO = "gloo"
     CUSTOM = "custom"
+    CINT8 = "cint8"
 
 
 ALL_REDUCE_FN: dict[AllReduceBackend, AllReduceFunc] = {
     AllReduceBackend.GLOO: gloo_all_reduce,
     AllReduceBackend.CUSTOM: ring_allreduce,
+    AllReduceBackend.CINT8: ring_allreduce_c,
 }

--- a/tests/test_c/conftest.py
+++ b/tests/test_c/conftest.py
@@ -1,0 +1,41 @@
+import pytest
+import socket
+from contextlib import contextmanager
+import os
+from unittest import mock
+
+
+def get_random_available_port():
+    # https://stackoverflow.com/questions/1365265/on-localhost-how-do-i-pick-a-free-port-number
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture()
+def random_available_port():
+    return get_random_available_port()
+
+
+@pytest.fixture()
+def dist_environment() -> callable:
+    @contextmanager
+    def dist_environment(
+        random_available_port, backend=None, rank=0, local_rank=0, world_size=1, local_world_size=1, global_unique_id=""
+    ):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "GLOBAL_UNIQUE_ID": global_unique_id,
+                "RANK": str(rank),
+                "WORLD_SIZE": str(world_size),
+                "LOCAL_RANK": str(local_rank),
+                "LOCAL_WORLD_SIZE": str(local_world_size),
+                "MASTER_ADDR": "localhost",
+                "MASTER_PORT": str(random_available_port),
+                "ZERO_BAND_LOG_LEVEL": "DEBUG",
+            },
+        ):
+            yield
+
+    return dist_environment

--- a/tests/test_c/test_collectives.py
+++ b/tests/test_c/test_collectives.py
@@ -1,0 +1,52 @@
+import torch
+import torch.distributed as dist
+from zeroband.C.collectives import ring_allreduce
+from zeroband.collectives import ring_allreduce as ring_allreduce_py
+from zeroband.C.compression import uniform_8bit_quantize
+import math
+import pytest
+import multiprocessing as mp
+
+N = 1_000_000
+TIME_COUNT = 2
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_ring_allreduce(world_size: int, random_available_port: int, dist_environment):
+    def all_reduce(rank: int, world_size: int):
+        with dist_environment(random_available_port, "gloo", rank=rank, world_size=world_size):
+            dist.init_process_group(backend="gloo")
+            rank = dist.get_rank()
+            pg = dist.distributed_c10d._get_default_group()
+            a = torch.randn(N) * 10
+            b = torch.clone(a)
+            c = torch.clone(a)
+
+            ring_allreduce(a, dist.ReduceOp.SUM, pg)
+            ring_allreduce_py(b, dist.ReduceOp.SUM, pg, quantization_func=uniform_8bit_quantize)
+            dist.all_reduce(c, dist.ReduceOp.SUM, group=pg)
+
+            if rank == 0:
+                error_new = torch.norm(a - c)
+                diff_new = (a - c).abs()
+                error_old = torch.norm(b - c)
+                diff_old = (b - c).abs()
+                print(
+                    f"[New] norm: {error_new:.4f} diff mean: {diff_new.mean():.4f} std: {diff_new.std()} max: {diff_new.max():.4f}"
+                )
+                print(
+                    f"[Old] norm: {error_old:.4f} diff mean: {diff_old.mean():.4f} std: {diff_old.std()} max: {diff_old.max():.4f}"
+                )
+
+                assert (error_new - error_old).abs() / math.sqrt(N) < 0.5
+
+            dist.destroy_process_group()
+
+    # Perform ring all-reduce
+    processes = [mp.Process(target=all_reduce, args=(rank, world_size)) for rank in range(world_size)]
+    for p in processes:
+        p.start()
+    for p in processes:
+        p.join()
+        if p.exitcode != 0:
+            pytest.fail(f"Process {p.pid} failed with exit code {p.exitcode}")


### PR DESCRIPTION
- [ ] Remove the quantizes in the all-gather
- [ ] Benchmark each section to identify points of slowness

Seems we have >4x already. Maybe we can merge already and remove the extra quantizes in the future.

<img width="271" alt="image" src="https://github.com/user-attachments/assets/e820934d-758c-4236-b693-6f2b5d2197cd">

<img width="907" alt="image" src="https://github.com/user-attachments/assets/a2a473fc-68b6-4904-85bf-76acce209b25">

