### PR TITLE
Non block copy in offloading

### DIFF
--- a/src/zeroband/diloco.py
+++ b/src/zeroband/diloco.py
@@ -133,7 +133,7 @@ class Diloco:
 
         self._logger.debug("sync inner model")
         for param_offloaded, param in zip(self.param_list_cpu, model.parameters()):
-            param.data.to_local().copy_(param_offloaded.data.to_local())
+            param.data.to_local().copy_(param_offloaded.data.to_local(), non_blocking=True)
 
     def get_offloaded_param(self, model: nn.Module) -> list[nn.Parameter]:
         """
@@ -160,7 +160,7 @@ class Diloco:
             data_tensor = self.offloaded_data_flat_tensor.as_strided(target.size(), target.stride(), current_offset)
             grad_tensor = self.offloaded_grad_flat_tensor.as_strided(target.size(), target.stride(), current_offset)
             current_offset += data_tensor.numel()
-            data_tensor.copy_(target)
+            data_tensor.copy_(target, non_blocking=True)
 
             offloaded_param = nn.Parameter(
                 DTensor.from_local(


### PR DESCRIPTION
Might be a bit faster because we can get some overlap with the main process execution. I wonder if DTensor.from_local causes block though, theoretically it doesnt care about the data so should not cause the copy to block but idk.