### PR TITLE
save data loader ckpt in its own folder

### DIFF
--- a/src/zeroband/checkpoint.py
+++ b/src/zeroband/checkpoint.py
@@ -338,7 +338,6 @@ class CkptManager:
 
             dcp.save(self.states, checkpoint_id=ckpt_path)
 
-
             ## we have two formats to to save the dataloader:
             ## 1. v1: save the dataloader in the same file as the outer optimizer
             ## 2. v2: save the dataloader in a data folder inside the ckpt path
@@ -395,7 +394,6 @@ class CkptManager:
         if self.live_server is not None:
             shutil.rmtree(self.shm_path, ignore_errors=True)
             self.live_server.stop()
-
         self.wait_for_blocking_job()
 
     def load(self, resume_ckpt_path: str, diloco_rank: int | None = None, skip_dataloader: bool = False) -> None:
@@ -430,9 +428,9 @@ class CkptManager:
 
         if not skip_dataloader:
             if "data_loader" in rank_state_dict.keys():
-                if self.config.data_version == "v1":
-                    self._logger.warning("v1 data tis set but we are loading a v2 ckpt")
-                
+                if self.config.data_version == "v2":
+                    self._logger.warning("v2 data tis set but we are loading a v1 ckpt")
+
                 self.dataloader.load_state_dict(rank_state_dict["data_loader"])
             else:
                 with open(os.path.join(resume_ckpt_path, "data", f"_{world_info.local_rank}.pt"), "rb") as f:

--- a/src/zeroband/checkpoint.py
+++ b/src/zeroband/checkpoint.py
@@ -157,7 +157,7 @@ class CkptConfig(BaseConfig):
     live_recovery: bool = False
     live_recovery_rank_src: int = 0
 
-    data_version: Literal["v1", "v2"] = "v1"
+    data_version: Literal["v1", "v2"] = "v2"
     data_path: str | None = None
 
     @model_validator(mode="after")

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -245,7 +245,11 @@ def train(config: Config):
 
     if config.ckpt.resume is not None:
         # all is inplace
-        ckpt_manager.load(resume_ckpt_path=config.ckpt.resume, skip_dataloader=config.ckpt.load_dataloader)
+        ckpt_manager.load(
+            resume_ckpt_path=config.ckpt.resume,
+            skip_dataloader=config.ckpt.skip_dataloader,
+            data_path=config.ckpt.data_path,
+        )
         if config.train.log_model_hash:
             logger.info(f"optimizer hash: {get_optimizer_signature(diloco.outer_optimizer)}")
 


### PR DESCRIPTION
This pr introduce a new data saving. 

V2: save into a data folder while v1 was saving in the same as the optimizer state.

This allow to send a lightweight ckpt file between node when if nescerray 