### PR TITLE
Reimplement async monitor handling

### DIFF
--- a/src/zeroband/utils/monitor.py
+++ b/src/zeroband/utils/monitor.py
@@ -1,3 +1,4 @@
+from collections import deque
 from typing import Any
 from zeroband.utils.logging import get_logger
 import aiohttp
@@ -9,7 +10,7 @@ async def _get_external_ip(max_retries=3, retry_delay=5):
     async with aiohttp.ClientSession() as session:
         for attempt in range(max_retries):
             try:
-                async with session.get('https://api.ipify.org', timeout=10) as response:
+                async with session.get("https://api.ipify.org", timeout=10) as response:
                     response.raise_for_status()
                     return await response.text()
             except ClientError:
@@ -38,11 +39,15 @@ class HttpMonitor:
         self.node_ip_address = None
         self.node_ip_address_fetch_status = None
 
-        self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self.loop)
+        # Create event loop only if one doesn't exist
+        try:
+            self.loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
 
-    def __del__(self):
-        self.loop.close()
+        self._pending_tasks = deque()
+        
 
     def _remove_duplicates(self):
         seen = set()
@@ -68,9 +73,40 @@ class HttpMonitor:
 
         self._handle_send_batch()
 
+    def __del__(self):
+        # Ensure all pending tasks are completed before closing
+        if hasattr(self, "loop") and self.loop is not None:
+            try:
+                pending = asyncio.all_tasks(self.loop)
+                self.loop.run_until_complete(asyncio.gather(*pending))
+            except Exception as e:
+                self._logger.error(f"Error cleaning up pending tasks: {str(e)}")
+            finally:
+                self.loop.close()
+
+    def _cleanup_completed_tasks(self):
+        """Remove completed tasks from the pending tasks queue"""
+        while self._pending_tasks and self._pending_tasks[0].done():
+            task = self._pending_tasks.popleft()
+            try:
+                task.result()  # This will raise any exceptions that occurred
+            except Exception as e:
+                self._logger.error(f"Error in completed batch send task: {str(e)}")
+
     def _handle_send_batch(self, flush: bool = False):
+        self._cleanup_completed_tasks()
+
         if len(self.data) >= self.log_flush_interval or flush:
-            self.loop.run_until_complete(self._send_batch())
+            batch = self.data[: self.log_flush_interval]
+            self.data = self.data[self.log_flush_interval :]
+            
+            if self.loop.is_running():
+                # If we're already in an event loop, create a task
+                task = self.loop.create_task(self._send_batch(batch))
+                self._pending_tasks.append(task)
+            else:
+                # If we're not in an event loop, run it directly
+                self.loop.run_until_complete(self._send_batch(batch))
 
     async def _set_node_ip_address(self):
         if self.node_ip_address is None and self.node_ip_address_fetch_status != "failed":
@@ -83,22 +119,16 @@ class HttpMonitor:
                 self.node_ip_address = ip_address
                 self.node_ip_address_fetch_status = "success"
 
-    async def _send_batch(self):
+    async def _send_batch(self, batch):
         import aiohttp
 
         self._remove_duplicates()
         await self._set_node_ip_address()
 
-        batch = self.data[:self.log_flush_interval]
         # set node_ip_address of batch
         batch = [{**log, "node_ip_address": self.node_ip_address} for log in batch]
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.auth_token}"
-        }
-        payload = {
-            "logs": batch
-        }
+        headers = {"Content-Type": "application/json", "Authorization": f"Bearer {self.auth_token}"}
+        payload = {"logs": batch}
         api = f"{self.base_url}/metrics/{self.run_id}/logs"
 
         try:
@@ -106,11 +136,11 @@ class HttpMonitor:
                 async with session.post(api, json=payload, headers=headers) as response:
                     if response is not None:
                         response.raise_for_status()
+                    self._logger.info(f"Sent {len(batch)} logs to server")
         except Exception as e:
             self._logger.error(f"Error sending batch to server: {str(e)}")
-            pass
+            return False
 
-        self.data = self.data[self.log_flush_interval :]
         return True
 
     async def _finish(self):
@@ -118,7 +148,9 @@ class HttpMonitor:
 
         # Send any remaining logs
         while self.data:
-            await self._send_batch()
+            batch = self.data
+            self.data = []
+            await self._send_batch(batch)
 
         headers = {"Content-Type": "application/json"}
         api = f"{self.base_url}/metrics/{self.run_id}/finish"
@@ -133,4 +165,6 @@ class HttpMonitor:
     def finish(self):
         self.set_stage("finishing")
 
-        self.loop.run_until_complete(self._finish())
+        # Clean up any remaining tasks
+        pending = asyncio.all_tasks(self.loop)
+        self.loop.run_until_complete(asyncio.gather(*pending))

--- a/src/zeroband/utils/monitor.py
+++ b/src/zeroband/utils/monitor.py
@@ -136,7 +136,6 @@ class HttpMonitor:
                 async with session.post(api, json=payload, headers=headers) as response:
                     if response is not None:
                         response.raise_for_status()
-                    self._logger.info(f"Sent {len(batch)} logs to server")
         except Exception as e:
             self._logger.error(f"Error sending batch to server: {str(e)}")
             return False
@@ -165,6 +164,10 @@ class HttpMonitor:
     def finish(self):
         self.set_stage("finishing")
 
-        # Clean up any remaining tasks
-        pending = asyncio.all_tasks(self.loop)
-        self.loop.run_until_complete(asyncio.gather(*pending))
+        if self.loop.is_running():
+            # If we're already in an event loop, create a task
+            task = self.loop.create_task(self._finish())
+            self._pending_tasks.append(task)
+        else:
+            # If we're not in an event loop, run it directly
+            self.loop.run_until_complete(self._finish())


### PR DESCRIPTION
We had to revert #131 since it broke log submission.
This PR re-implements it with fixes -- including how we handle async loops, as well as making batch creation synchronous.

Tested on 2xRTX3090s, logs are being sent and received on local protocol svc:
```bash
...
22:39:10 [INFO] [Rank 0] Pending tasks: deque([])
22:39:10 [INFO] [Rank 0] Cleaning up 0 completed tasks
22:39:10 [INFO] [Rank 0] step: 1, loss: 7.4207, diloco_peers: 2
22:39:10 [INFO] [Rank 0] Pending tasks: deque([])
22:39:10 [INFO] [Rank 0] Cleaning up 0 completed tasks
22:39:10 [INFO] [Rank 0] step: 2, loss: 7.4049, tokens_per_second: 262783.83, mfu: 1.52, diloco_peers: 2
22:39:10 [INFO] [Rank 0] Pending tasks: deque([])
22:39:10 [INFO] [Rank 0] Cleaning up 0 completed tasks
22:39:10 [INFO] [Rank 0] step: 3, loss: 7.4265, tokens_per_second: 278822.70, mfu: 1.62, diloco_peers: 2
22:39:10 [INFO] [Rank 0] Pending tasks: deque([])
22:39:10 [INFO] [Rank 0] Cleaning up 0 completed tasks
22:39:10 [INFO] [Rank 0] step: 4, loss: 7.4168, tokens_per_second: 284322.89, mfu: 1.65, diloco_peers: 2
22:39:10 [INFO] [Rank 0] Pending tasks: deque([])
22:39:10 [INFO] [Rank 0] Cleaning up 0 completed tasks
22:39:10 [INFO] [Rank 0] Sending batch with 5 logs
22:39:11 [INFO] [Rank 0] Sent 5 logs to server
22:39:11 [INFO] [Rank 0] step: 5, loss: 7.4077, tokens_per_second: 277327.57, mfu: 1.61, diloco_peers: 2
22:39:11 [INFO] [Rank 0] Pending tasks: deque([])
22:39:11 [INFO] [Rank 0] Cleaning up 0 completed tasks
22:39:11 [INFO] [Rank 0] Sending batch with 1 logs
22:39:11 [INFO] [Rank 0] Sent 1 logs to server
22:39:11 [DEBUG] [Rank 0] [0] Resolving world
22:39:11 [DEBUG] [Rank 0] Node 0 last heartbeat: 1729895950.8916602
22:39:11 [DEBUG] [Rank 0] Node 1 last heartbeat: 1729895950.8478436
22:39:11 [DEBUG] [Rank 0] Joiners (not admitting): [], Dead nodes: [], Evicting nodes: []
22:39:11 [DEBUG] [Rank 0] World resolved in 0.0012244440003996715 seconds
22:39:11 [DEBUG] [Rank 0] sync pseudo gradient  with world size 2
22:39:11 [DEBUG] [Rank 0] Waiting on barrier
22:39:11 [DEBUG] [Rank 0] [0] Monitored Barrier 0
22:39:11 [DEBUG] [Rank 0] Others have 600 seconds to resolve
22:39:12 [DEBUG] [Rank 0] Monitored barrier resolved in 0.20101371300552273 seconds
22:39:12 [DEBUG] [Rank 0] Beginning all reduce
22:39:12 [DEBUG] [Rank 0] 0/4 all reduce bucket done in 0.003842 seconds, numel: 262144
22:39:12 [DEBUG] [Rank 0] 1/4 all reduce bucket done in 0.006478 seconds, numel: 852480
22:39:12 [DEBUG] [Rank 0] 2/4 all reduce bucket done in 0.005521 seconds, numel: 852480
22:39:12 [DEBUG] [Rank 0] 3/4 all reduce bucket done in 0.002027 seconds, numel: 262400
22:39:12 [DEBUG] [Rank 0] All reduce takes 0.219897 seconds numels: 2229504
22:39:12 [INFO] [Rank 0] Sync psuedo-gradient in 0.265378 seconds
22:39:12 [INFO] [Rank 0] all reduce pseudo gradient in: 0.26548387900402304 seconds
22:39:12 [DEBUG] [Rank 0] sync inner model
22:39:12 [INFO] [Rank 0] effective mfu: 0.023154298032237574
22:39:12 [INFO] [Rank 0] Pending tasks: deque([])
22:39:12 [INFO] [Rank 0] Cleaning up 0 completed tasks
22:39:12 [INFO] [Rank 0] Sending batch with 1 logs
22:39:12 [INFO] [Rank 0] Sent 1 logs to server
22:39:12 [INFO] [Rank 0] Training finished, exiting ...
```