### PR TITLE
[Fix] zombie on main exception

### DIFF
--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -554,6 +554,7 @@ if __name__ == "__main__":
 
     try:
         train(config)
-    except:
+    except:  # noqa
+        # Subprocesses can prevent the main process from exiting, so we need to terminate them
         for p in _children:
             p.terminate()

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -2,6 +2,7 @@ import os
 from typing import Literal
 import time
 from pydantic import model_validator
+from multiprocessing.process import _children
 
 import torch
 from pydantic_config import parse_argv, BaseConfig
@@ -551,4 +552,8 @@ if __name__ == "__main__":
     config = Config(**parse_argv())
     logger.debug(f"config: {config.model_dump()}")
 
-    train(config)
+    try:
+        train(config)
+    except:
+        for p in _children:
+            p.terminate()


### PR DESCRIPTION
It seems that the zombie behavior is caused by lingering subprocesses.

In order to resolve it, we wrap the main trian method with a finally that terminates all subprocesses