### PR TITLE
Source uv only if not already on $PATH

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -36,8 +36,10 @@ main() {
     curl -LsSf https://astral.sh/uv/install.sh | sh
     
     log_info "Sourcing uv environment..."
-    source $HOME/.local/bin/env
-        
+    if ! command -v uv &> /dev/null; then
+        source $HOME/.local/bin/env
+    fi
+    
     log_info "Creating virtual environment..."
     uv venv
     


### PR DESCRIPTION
Previously, on a tensordock machine I was getting:
```sh
user@b68df229-93fa-43dd-b713-f265dc392497[x][2][~]$ curl -sSL https://raw.githubusercontent.com/PrimeIntellect-ai/prime/main/scripts/install/install.sh | bash

/* Stuff omitted */

[INFO] Sourcing uv environment...
main: line 39: /home/user/.local/bin/env: No such file or directory
```
The uv install didn't write the env file, because there was no need, uv was already on the $PATH. So I commented out the line and it worked. 

But the line did turn out to be necessary on runpod machines, because for whatever reason the $PATH was different there.

So, the solution is to do what uv install does, just add it to the $PATH if it isn't already there.