### PR TITLE
fix diloco not defined

### DIFF
--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -169,8 +169,7 @@ def train(config: Config):
         betas=(config.optim.adam_betas1, config.optim.adam_betas2),
     )
 
-    if config.diloco is not None:
-        diloco = Diloco(config.diloco, model, elastic_device_mesh)
+    diloco = Diloco(config.diloco, model, elastic_device_mesh) if config.diloco is not None else None
 
     scheduler = get_scheduler(
         sched_type=config.optim.sched_type,


### PR DESCRIPTION
mini PR to define the variable diloco to None even if it not used. THis is because we pass it to the log hash function in case of checkpoiting. BEfore this pr saving without diloco would have create yield an error