### PR TITLE
Add named runs and `get_env_config()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ cython_debug/
 
 # Aider
 .aider*
+
+# Files created while testing
+debug_I2_zero_band

--- a/configs/10B/H100_devel.toml
+++ b/configs/10B/H100_devel.toml
@@ -1,6 +1,8 @@
 name_model = "10B"
 project = "debug_I2_zero_band"
 metric_logger_type = "dummy"
+log_level = "DEBUG"
+run_name = "RUN NAME"
 
 [train]
 micro_bs = 1

--- a/scripts/all_reduce.py
+++ b/scripts/all_reduce.py
@@ -63,6 +63,6 @@ if __name__ == "__main__":
     torch.set_float32_matmul_precision("high")
     init_process_group(backend="gloo")
 
-    logger = get_logger()
+    logger = get_logger(config)
     main(config)
     destroy_process_group()

--- a/src/zeroband/config.py
+++ b/src/zeroband/config.py
@@ -1,13 +1,47 @@
-from typing import Literal
+from typing import Any, Literal, TypeAlias
+import os
 
 from pydantic import model_validator
 from pydantic_config import BaseConfig
 
-from zeroband.checkpoint import CkptConfig
-from zeroband.data import DataConfig
-from zeroband.diloco import DilocoConfig
+from zeroband.collectives import Compression
 from zeroband.models.llama.model import AttnFnType
-from zeroband.optimizers import OptimizersConfig, AdamConfig
+
+
+class DataConfig(BaseConfig):
+    dataset_name_or_paths: str = "datasets/fineweb-edu"
+    val_dataset_name_or_paths: str | None = None
+    seq_length: int = 1024
+    fake: bool = False
+    num_workers: int = 4
+    max_train_samples: int | None = None
+    max_eval_samples: int | None = None
+    dataset_ratio: str | None = None
+    data_rank: int | None = None
+    data_world_size: int | None = None
+    reverse_data_files: bool = False
+    split_by_data_rank: bool = True
+
+class AdamConfig(BaseConfig):
+    type: Literal["adam"] = "adam" # the literal is used to distinguish between the different optimizers configuration in the union type
+    lr: float = 4e-4
+    weight_decay: float = 0.1
+    betas1: float = 0.9
+    betas2: float = 0.95
+
+
+class SoapConfig(BaseConfig):
+    type: Literal["soap"] = "soap"
+    lr: float = 4e-4
+    weight_decay: float = 1e-05
+    betas1: float = 0.9
+    betas2: float = 0.95
+
+    max_preconditioner_dim: int = 8192
+    precondition_frequency: int = 100
+
+
+OptimizersConfig: TypeAlias = AdamConfig | SoapConfig
 
 
 class OptimConfig(BaseConfig):
@@ -28,6 +62,13 @@ class OptimConfig(BaseConfig):
     z_loss_weight: float = 2e-4
     num_chunks: int | None = None
 
+
+class DilocoConfig(BaseConfig):
+    outer_lr: float = 0.7
+    inner_steps: int
+    compression: Compression = Compression.NO
+
+    retry_all_reduce: int = 3
 
 class MemoryProfilerConfig(BaseConfig):
     freq: int = 10
@@ -59,15 +100,65 @@ class MonitorConfig(BaseConfig):
     auth_token: str | None = None
 
 
+class RemoteConfig(BaseConfig):
+    path: str  # could be a s3 path
+    interval: int
+
+
+class CkptConfig(BaseConfig):
+    path: str | None = None
+    interval: int | None = None
+    topk: int | None = None
+
+    remote: RemoteConfig | None = None
+
+    remote_data_path: str | None = None
+    remote_data_load: bool = False
+
+    resume: str | None = None
+
+    skip_dataloader: bool = False
+
+    live_recovery_rank_src: int | None = None
+
+    data_path: str | None = None
+
+    token_count: int | None = None
+
+    @model_validator(mode="after")
+    def validate_path_and_interval(self):
+        if (self.path is None) != (self.interval is None):
+            raise ValueError("path and interval must be both set or both None")
+        if self.path is None and self.remote is not None:
+            raise ValueError("remote_path is set but path is not set")
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_remote_data_path(self):
+        if self.remote_data_load and self.data_path is not None:
+            raise ValueError("remote_data_load and data_path are mutually exclusive")
+
+        if self.remote_data_load and self.remote_data_path is None:
+            raise ValueError("remote_data_load is set but remote_data_path is not set")
+        return self
+
+
 class Config(BaseConfig):
     # main config
     name_model: Literal["debugmodel", "150M", "271M", "1B", "7B", "10B", "13B", "26B", "70B"] = "150M"
     type_model: Literal["llama2", "llama3"] = "llama3"
 
+    # Project/Run
     project: str = "zeroband"
     run_id: str | None = None
+    run_name: str | None = None
+
+    # Logger
     metric_logger_type: Literal["wandb", "dummy"] = "wandb"
     wandb_resume: bool = False
+    log_level: Literal["NOTSET", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+    log_all_rank: bool = False
 
     # sub config
     diloco: DilocoConfig | None = None
@@ -91,4 +182,70 @@ class Config(BaseConfig):
         if self.ckpt is not None and self.ckpt.live_recovery_rank_src is not None and self.diloco is None:
             raise ValueError("live_recovery_rank_src is only supported with diloco")
         return self
+
+
+def get_env_config(config: Config | None, item: str | None, default: Any | None = None) -> Any:
+    """
+    Get a config value from the environment or the config.
+        item: item is of the form "train.memory_profiler.freq"
+        default: default value if not found
+
+    If either config or item are None, returns default. This is so you can call get_logger() as before.
+
+    Examples:
+    ```
+    # Returns ZERO_BAND_RUN_NAME if set in env.
+    # Otherwise returns config.run_name.
+    get_env_config(config, "run_name")
+    ```
+    ```
+    # Returns ZERO_BAND_TRAIN_MEMORY_PROFILER_FREQ if set in env.
+    # Then returns 10 if train or config.train.memory_profiler are None.
+    # Otherwise, returns the value of config.train.memory_profiler.freq.
+    get_env_config(config, "train.memory_profiler.freq", 10)
+    ```
+
+    """
+
+    if config is None or item is None:
+        return default
+
+    # Check env
+    env_name = "ZERO_BAND_" + item.upper().replace(".", "_")
+    if env_name in os.environ:
+        return os.environ[env_name]
+
+    # Check config
+    spt = item.split(".")
+    cfg: Any = config
+    for s in spt:
+        print(cfg)
+        print(s)
+        if cfg is None:
+            return default
+        try:
+            cfg = getattr(cfg, s)
+        except AttributeError:
+            # TODO: Fancier error message for debugging
+            raise ValueError(f"Config item {item} not found.")
+
+    return cfg
+
+def get_env_config_bool(config: Config | None, item: str | None, default: bool  | None = None) -> bool:
+    """
+    Call get_env_config and convert strings to bools where makes sense.
+
+    Throws an exception if the value is not a string and not convertable.
+    """
+
+    val = get_env_config(config, item, default)
+    if val is None and default is not None:
+        return default
+    if val is None:
+        return False
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.lower() == "true" or val.lower() == "1"
+    return bool(val)
 

--- a/src/zeroband/data.py
+++ b/src/zeroband/data.py
@@ -3,8 +3,8 @@ import random
 from typing import Any, Generator, Optional, List, Dict, TypedDict, Union
 import functools
 
-from pydantic_config import BaseConfig
 from zeroband.utils.logging import get_logger
+from zeroband.config import DataConfig
 
 import torch
 from torch.utils.data import IterableDataset, Dataset
@@ -20,22 +20,7 @@ TEST_VOCAB_SIZE = 1024
 
 # TODO sami: make sure the init of the model is the same on all rank
 
-logger = get_logger(__name__)
-
-
-class DataConfig(BaseConfig):
-    dataset_name_or_paths: str = "datasets/fineweb-edu"
-    val_dataset_name_or_paths: Optional[str] = None
-    seq_length: int = 1024
-    fake: bool = False
-    num_workers: int = 4
-    max_train_samples: Optional[int] = None
-    max_eval_samples: Optional[int] = None
-    dataset_ratio: Optional[str] = None
-    data_rank: Optional[int] = None
-    data_world_size: Optional[int] = None
-    reverse_data_files: bool = False
-    split_by_data_rank: bool = True
+logger = get_logger(name=__name__)
 
 
 class FakeTokenizedDataset(IterableDataset):

--- a/src/zeroband/diloco.py
+++ b/src/zeroband/diloco.py
@@ -1,23 +1,15 @@
 import re
 import time
-from pydantic_config import BaseConfig
 import torch
 from torch import nn
-from zeroband.collectives import Compression, all_reduce
 from zeroband.comms import ElasticDeviceMesh
+from zeroband.collectives import Compression, all_reduce
 from zeroband.utils.world_info import get_world_info
 from zeroband.utils.logging import get_logger
+from zeroband.config import DilocoConfig
 import torch.distributed as dist
 from torch.distributed._tensor.api import DTensor
 from functools import lru_cache
-
-
-class DilocoConfig(BaseConfig):
-    outer_lr: float = 0.7
-    inner_steps: int
-    compression: Compression = Compression.NO
-
-    retry_all_reduce: int = 3
 
 
 @lru_cache(maxsize=None)

--- a/src/zeroband/optimizers.py
+++ b/src/zeroband/optimizers.py
@@ -1,5 +1,4 @@
-from typing import Iterable, Literal, TypeAlias
-from pydantic_config import BaseConfig
+from typing import Iterable
 import torch
 from distributed_shampoo import (
     DefaultEigenvalueCorrectedShampooConfig,
@@ -7,27 +6,7 @@ from distributed_shampoo import (
     FullyShardShampooConfig,
     ShampooPT2CompileConfig,
 )
-
-class AdamConfig(BaseConfig):
-    type: Literal["adam"] = "adam" # the literal is used to distinguish between the different optimizers configuration in the union type
-    lr: float = 4e-4
-    weight_decay: float = 0.1
-    betas1: float = 0.9
-    betas2: float = 0.95
-
-class SoapConfig(BaseConfig):
-    type: Literal["soap"] = "soap"
-    lr: float = 4e-4
-    weight_decay: float = 1e-05
-    betas1: float = 0.9
-    betas2: float = 0.95
-
-    max_preconditioner_dim: int = 8192
-    precondition_frequency: int = 100
-
-
-OptimizersConfig: TypeAlias = AdamConfig | SoapConfig
-
+from zeroband.config import AdamConfig, SoapConfig, OptimizersConfig
 
 def get_optimizer(params: Iterable[torch.nn.Parameter], config: OptimizersConfig) -> torch.optim.Optimizer:
     if isinstance(config, AdamConfig):

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -495,8 +495,9 @@ if __name__ == "__main__":
     torch.set_float32_matmul_precision("high")
     torch.manual_seed(42)
 
+    config = Config(**parse_argv())  # type: ignore
     world_info = get_world_info()
-    logger = get_logger()
+    logger = get_logger(config)
 
     torch.cuda.set_device(world_info.local_rank)
 
@@ -508,7 +509,6 @@ if __name__ == "__main__":
             else:
                 logger.debug(" " * indent + f"{key}: {value}")
 
-    config = Config(**parse_argv())  # type: ignore
     logger.debug("config:")
     pretty_dict(config.model_dump())
 

--- a/src/zeroband/utils/metric_logger.py
+++ b/src/zeroband/utils/metric_logger.py
@@ -2,6 +2,8 @@ import pickle
 from typing import Any, Protocol
 import importlib.util
 
+from zeroband.config import get_env_config
+
 
 class MetricLogger(Protocol):
     def __init__(self, project, config): ...
@@ -18,8 +20,10 @@ class WandbMetricLogger(MetricLogger):
 
         import wandb
 
+        run_name = get_env_config(config, "run_name")
+
         wandb.init(
-            project=project, config=config, resume="auto" if resume else None
+            project=project, config=config, name=run_name, resume="auto" if resume else None
         )  # make wandb reuse the same run id if possible
 
     def log(self, metrics: dict[str, Any]):


### PR DESCRIPTION
Let's slowly unify the way we handle configs and env vars. We can slowly move over to using the new `get_env_config()`. 

```py
# Then returns ZERO_BAND_TRAIN_MEMORY_PROFILER_FREQ if set in env.
# Then returns 10 if train or config.train.memory_profiler are None.
# Otherwise, returns the value of config.train.memory_profiler.freq.
get_env_config(config, "train.memory_profiler.freq", 10)
```

Hopefully being able to use an env var for named runs will prevent losing experiment results in the future. And having all the configs in one place demystifies some things.