### PR TITLE
Replace `get_env_config()` with `resolve_env_vars()`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ cython_debug/
 
 # Aider
 .aider*
+
+# Files created while testing
+debug_I2_zero_band

--- a/scripts/all_reduce.py
+++ b/scripts/all_reduce.py
@@ -4,8 +4,10 @@ from torch.distributed import destroy_process_group, init_process_group, ReduceO
 import torch.utils.benchmark as benchmark
 
 from zeroband.collectives import Compression, all_reduce
+from zeroband.config import resolve_env_vars
 from zeroband.utils.world_info import get_world_info
 from zeroband.utils.logging import get_logger
+
 from enum import Enum
 
 
@@ -63,6 +65,6 @@ if __name__ == "__main__":
     torch.set_float32_matmul_precision("high")
     init_process_group(backend="gloo")
 
-    logger = get_logger(config)
+    logger = get_logger()
     main(config)
     destroy_process_group()

--- a/scripts/all_reduce.py
+++ b/scripts/all_reduce.py
@@ -4,7 +4,6 @@ from torch.distributed import destroy_process_group, init_process_group, ReduceO
 import torch.utils.benchmark as benchmark
 
 from zeroband.collectives import Compression, all_reduce
-from zeroband.config import resolve_env_vars
 from zeroband.utils.world_info import get_world_info
 from zeroband.utils.logging import get_logger
 

--- a/scripts/convert_dl_state.py
+++ b/scripts/convert_dl_state.py
@@ -4,6 +4,7 @@
 # python scripts/convert_dl_state.py @configs/10B/H100.toml --input_path /workspace/step_49200/diloco_0/data/_3.pt --output_path ./meow.pt --rank 3 --world_size 8
 
 import torch
+from zeroband.config import resolve_env_vars
 from zeroband.data import get_dataloader
 from transformers import AutoTokenizer
 from zeroband.train import Config
@@ -133,6 +134,7 @@ def test_dl(config: ExportConfig):
 if __name__ == "__main__":
     logger = get_logger()
     config = ExportConfig(**parse_argv())
+    resolve_env_vars(config)
     logger.debug(f"config: {config.model_dump()}")
 
     main(config)

--- a/scripts/export_dcp.py
+++ b/scripts/export_dcp.py
@@ -7,6 +7,7 @@ import torch
 from typing import Literal
 import torch.distributed.checkpoint as dcp
 from zeroband.models.llama import get_model
+from zeroband.config import resolve_env_vars
 from zeroband.checkpoint import ModelWrapper
 from zeroband.utils import get_module_signature
 from zeroband.train import Config
@@ -221,6 +222,7 @@ def main(config: ExportConfig):
 if __name__ == "__main__":
     logger = get_logger()
     config = ExportConfig(**parse_argv())
+    resolve_env_vars(config)
     logger.debug(f"config: {config.model_dump()}")
 
     main(config)

--- a/scripts/skip_data.py
+++ b/scripts/skip_data.py
@@ -19,7 +19,7 @@ from pydantic_config import parse_argv
 
 from transformers import AutoTokenizer
 from zeroband.checkpoint import CkptManager
-
+from zeroband.config import resolve_env_vars
 from zeroband.train import Config
 
 from zeroband.data import get_dataloader
@@ -83,5 +83,6 @@ if __name__ == "__main__":
     logger = get_logger()
 
     config = Config(**parse_argv())
+    resolve_env_vars(config)
 
     skip_data(config)

--- a/src/zeroband/config.py
+++ b/src/zeroband/config.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, Literal, TypeAlias
+from typing import Any, Literal, TypeAlias
 import os
 
 from pydantic import create_model, model_validator

--- a/src/zeroband/config.py
+++ b/src/zeroband/config.py
@@ -219,8 +219,6 @@ def get_env_config(config: Config | None, item: str | None, default: Any | None 
     spt = item.split(".")
     cfg: Any = config
     for s in spt:
-        print(cfg)
-        print(s)
         if cfg is None:
             return default
         try:

--- a/src/zeroband/config.py
+++ b/src/zeroband/config.py
@@ -143,6 +143,8 @@ class CkptConfig(BaseConfig):
         return self
 
 
+ENV_VAR_PREFIX = "ZERO_BAND_"
+
 class Config(BaseConfig):
     # main config
     name_model: Literal["debugmodel", "150M", "271M", "1B", "7B", "10B", "13B", "26B", "70B"] = "150M"
@@ -216,7 +218,7 @@ def resolve_env_vars(config: Config) -> None:
 
         for field_name, _ in config_obj.__class__.model_fields.items():
             # Build the full env var name
-            full_env_var = f"ZERO_BAND_{prefix}_{field_name}".upper() if prefix else f"ZERO_BAND_{field_name}".upper()
+            full_env_var = f"{ENV_VAR_PREFIX}{prefix}_{field_name}".upper() if prefix else f"{ENV_VAR_PREFIX}{field_name}".upper()
 
             # Try to resolve the field directly using the local field name
             value = _resolve_value(full_env_var, field_name, config_obj)
@@ -236,7 +238,7 @@ def resolve_env_vars(config: Config) -> None:
             return valid_vars
 
         for field_name, _ in config_obj.__class__.model_fields.items():
-            full_env_var = f"ZERO_BAND_{prefix}_{field_name}".upper() if prefix else f"ZERO_BAND_{field_name}".upper()
+            full_env_var = f"{ENV_VAR_PREFIX}{prefix}_{field_name}".upper() if prefix else f"{ENV_VAR_PREFIX}{field_name}".upper()
             valid_vars.add(full_env_var)
 
             field_value = getattr(config_obj, field_name)
@@ -250,12 +252,12 @@ def resolve_env_vars(config: Config) -> None:
     valid_env_vars = _get_valid_env_vars("", config)
     invalid_vars = []
     for env_var in os.environ:
-        if env_var.startswith("ZERO_BAND_") and env_var not in valid_env_vars:
+        if env_var.startswith(ENV_VAR_PREFIX) and env_var not in valid_env_vars:
             invalid_vars.append(env_var)
 
     if invalid_vars:
         raise ValueError(
-            f"Found invalid environment variables with ZERO_BAND_ prefix: {', '.join(invalid_vars)}\n"
+            f"Found invalid environment variables with {ENV_VAR_PREFIX} prefix: {', '.join(invalid_vars)}\n"
              "See the full list of valid config veriables in src/zeroband/config.py."
         )
 

--- a/src/zeroband/config.py
+++ b/src/zeroband/config.py
@@ -204,7 +204,7 @@ def resolve_env_vars(config: Config) -> None:
 
             try:
                 # Create a temporary model with just this field, then validate and rip it out.
-                py_model = create_model('TempModel', __base__ = BaseConfig, **{field_name: (field_info.annotation, ...)})
+                py_model = create_model('TempModel', __base__ = BaseConfig, **{field_name: (field_info.annotation, ...)}) # type: ignore
                 validated = py_model.model_validate({field_name: value})
                 return getattr(validated, field_name)
             except Exception as e:

--- a/src/zeroband/config.py
+++ b/src/zeroband/config.py
@@ -1,7 +1,7 @@
-from typing import Any, Literal, TypeAlias
+from typing import Any, Type, Literal, TypeAlias
 import os
 
-from pydantic import model_validator
+from pydantic import create_model, model_validator
 from pydantic_config import BaseConfig
 
 from zeroband.collectives import Compression
@@ -184,66 +184,81 @@ class Config(BaseConfig):
         return self
 
 
-def get_env_config(config: Config | None, item: str | None, default: Any | None = None) -> Any:
+def resolve_env_vars(config: Config) -> None:
     """
-    Get a config value from the environment or the config.
-        item: item is of the form "train.memory_profiler.freq"
-        default: default value if not found
-
-    If either config or item are None, returns default. This is so you can call get_logger() as before.
-
-    Examples:
-    ```
-    # Returns ZERO_BAND_RUN_NAME if set in env.
-    # Otherwise returns config.run_name.
-    get_env_config(config, "run_name")
-    ```
-    ```
-    # Returns ZERO_BAND_TRAIN_MEMORY_PROFILER_FREQ if set in env.
-    # Then returns 10 if train or config.train.memory_profiler are None.
-    # Otherwise, returns the value of config.train.memory_profiler.freq.
-    get_env_config(config, "train.memory_profiler.freq", 10)
-    ```
-
+    Resolve environment variables for config fields.
+    Modifies the config in place.
+    Environment variables should be prefixed with ZERO_BAND_.
     """
 
-    if config is None or item is None:
-        return default
+    def _resolve_value(env_var: str, field_name: str, config_obj: Any) -> Any:
+        """
+        Resolve a single value from an environment variable
+        env_var: full environment variable name (e.g. ZERO_BAND_TRAIN_MICRO_BS)
+        field_name: actual field name in the config object (e.g. micro_bs)
+        """
+        value = os.environ.get(env_var)
+        if value is not None:
+            if (field_info := config_obj.__class__.model_fields.get(field_name)) is None:
+                raise AttributeError(f"Config {config_obj} has no attribute {field_name}")
 
-    # Check env
-    env_name = "ZERO_BAND_" + item.upper().replace(".", "_")
-    if env_name in os.environ:
-        return os.environ[env_name]
+            try:
+                # Create a temporary model with just this field, then validate and rip it out.
+                py_model = create_model('TempModel', __base__ = BaseConfig, **{field_name: (field_info.annotation, ...)})
+                validated = py_model.model_validate({field_name: value})
+                return getattr(validated, field_name)
+            except Exception as e:
+                raise ValueError(f"Error setting {env_var}={value}: {e}")
+        return None
 
-    # Check config
-    spt = item.split(".")
-    cfg: Any = config
-    for s in spt:
-        if cfg is None:
-            return default
-        try:
-            cfg = getattr(cfg, s)
-        except AttributeError:
-            # TODO: Fancier error message for debugging
-            raise ValueError(f"Config item {item} not found.")
+    def _resolve_nested(prefix: str, config_obj: Any) -> None:
+        if not hasattr(config_obj, 'model_fields'):
+            return
 
-    return cfg
+        for field_name, _ in config_obj.__class__.model_fields.items():
+            # Build the full env var name
+            full_env_var = f"ZERO_BAND_{prefix}_{field_name}".upper() if prefix else f"ZERO_BAND_{field_name}".upper()
 
-def get_env_config_bool(config: Config | None, item: str | None, default: bool  | None = None) -> bool:
-    """
-    Call get_env_config and convert strings to bools where makes sense.
+            # Try to resolve the field directly using the local field name
+            value = _resolve_value(full_env_var, field_name, config_obj)
+            if value is not None:
+                setattr(config_obj, field_name, value)
 
-    Throws an exception if the value is not a string and not convertable.
-    """
+            # Handle nested configs
+            field_value = getattr(config_obj, field_name)
+            if field_value is not None and hasattr(field_value, 'model_fields'):
+                # Pass the prefix for building env var names, but use local field names for lookup
+                _resolve_nested(f"{prefix}_{field_name}" if prefix else field_name, field_value)
 
-    val = get_env_config(config, item, default)
-    if val is None and default is not None:
-        return default
-    if val is None:
-        return False
-    if isinstance(val, bool):
-        return val
-    if isinstance(val, str):
-        return val.lower() == "true" or val.lower() == "1"
-    return bool(val)
+    def _get_valid_env_vars(prefix: str, config_obj: Any) -> set[str]:
+        """Recursively collect all valid environment variable names"""
+        valid_vars = set()
+        if not hasattr(config_obj, 'model_fields'):
+            return valid_vars
 
+        for field_name, _ in config_obj.__class__.model_fields.items():
+            full_env_var = f"ZERO_BAND_{prefix}_{field_name}".upper() if prefix else f"ZERO_BAND_{field_name}".upper()
+            valid_vars.add(full_env_var)
+
+            field_value = getattr(config_obj, field_name)
+            if field_value is not None and hasattr(field_value, 'model_fields'):
+                nested_prefix = f"{prefix}_{field_name}" if prefix else field_name
+                valid_vars.update(_get_valid_env_vars(nested_prefix, field_value))
+
+        return valid_vars
+
+    # Check for any invalid ZERO_BAND_ environment variables
+    valid_env_vars = _get_valid_env_vars("", config)
+    invalid_vars = []
+    for env_var in os.environ:
+        if env_var.startswith("ZERO_BAND_") and env_var not in valid_env_vars:
+            invalid_vars.append(env_var)
+
+    if invalid_vars:
+        raise ValueError(
+            f"Found invalid environment variables with ZERO_BAND_ prefix: {', '.join(invalid_vars)}\n"
+             "See the full list of valid config veriables in src/zeroband/config.py."
+        )
+
+    # Now resolve the valid ones.
+    _resolve_nested("", config)

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -203,7 +203,7 @@ def train(config: Config):
         logger_cls = WandbMetricLogger if config.metric_logger_type == "wandb" else DummyMetricLogger
         metric_logger = logger_cls(
             project=config.project,
-            config={"config": config.model_dump(), "world_info": world_info.json()},
+            logger_config={"config": config.model_dump(), "world_info": world_info.json()},
             resume=config.wandb_resume,
         )
     else:

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -10,7 +10,7 @@ from torch.autograd.profiler import record_function
 
 from zeroband.checkpoint import CkptManager, TrainingProgress
 from zeroband.comms import ElasticDeviceMesh
-from zeroband.config import Config
+from zeroband.config import Config, resolve_env_vars
 from zeroband.data import TEST_VOCAB_SIZE, get_dataloader
 from zeroband.diloco import Diloco
 from zeroband.loss import compute_cross_entropy_loss
@@ -83,7 +83,7 @@ def train(config: Config):
     assert config.optim.batch_size % world_info.local_world_size == 0
     batch_size = config.optim.batch_size // world_info.local_world_size
 
-    assert batch_size % config.train.micro_bs == 0
+    assert batch_size % config.train.micro_bs == 0, f'The micro batch size ({config.train.micro_bs}) must divide the number of samples on each GPU ({batch_size}).'
     gradient_accumulation_steps = batch_size // config.train.micro_bs
 
     if config.ckpt is not None and config.ckpt.interval is not None and config.diloco is not None:
@@ -496,6 +496,7 @@ if __name__ == "__main__":
     torch.manual_seed(42)
 
     config = Config(**parse_argv())  # type: ignore
+    resolve_env_vars(config)
     world_info = get_world_info()
     logger = get_logger(config)
 
@@ -504,12 +505,12 @@ if __name__ == "__main__":
     def pretty_dict(d, indent=2):
         for key, value in d.items():
             if isinstance(value, dict):
-                logger.debug(" " * indent + f"{key}:")
+                logger.info(" " * indent + f"{key}:")
                 pretty_dict(value, indent + 2)
             else:
-                logger.debug(" " * indent + f"{key}: {value}")
+                logger.info(" " * indent + f"{key}: {value}")
 
-    logger.debug("config:")
+    logger.info("config:")
     pretty_dict(config.model_dump())
 
     try:

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -505,12 +505,12 @@ if __name__ == "__main__":
     def pretty_dict(d, indent=2):
         for key, value in d.items():
             if isinstance(value, dict):
-                logger.info(" " * indent + f"{key}:")
+                logger.debug(" " * indent + f"{key}:")
                 pretty_dict(value, indent + 2)
             else:
-                logger.info(" " * indent + f"{key}: {value}")
+                logger.debug(" " * indent + f"{key}: {value}")
 
-    logger.info("config:")
+    logger.debug("config:")
     pretty_dict(config.model_dump())
 
     try:

--- a/src/zeroband/utils/logging.py
+++ b/src/zeroband/utils/logging.py
@@ -29,6 +29,8 @@ def get_logger(config: Config | None = None, name: str | None = None) -> logging
     if logger is not None:
         return logger
 
+    assert isinstance(config, Config)
+
     try:
         world_info = get_world_info()
     except KeyError:
@@ -37,8 +39,6 @@ def get_logger(config: Config | None = None, name: str | None = None) -> logging
         world_info = WorldInfo.__new__(WorldInfo)
         world_info.local_rank = 0
     logger = logging.getLogger(name or __name__)
-
-    assert isinstance(config.log_level, str)
 
     if world_info.local_rank == 0:
         logger.setLevel(level=getattr(logging, config.log_level, logging.INFO))

--- a/src/zeroband/utils/logging.py
+++ b/src/zeroband/utils/logging.py
@@ -1,6 +1,6 @@
 import logging
 
-from zeroband.config import Config, get_env_config, get_env_config_bool
+from zeroband.config import Config
 from zeroband.utils.world_info import get_world_info
 
 logger = None
@@ -38,14 +38,13 @@ def get_logger(config: Config | None = None, name: str | None = None) -> logging
         world_info.local_rank = 0
     logger = logging.getLogger(name or __name__)
 
-    log_level = get_env_config(config, "log_level", "INFO")
-    assert isinstance(log_level, str)
+    assert isinstance(config.log_level, str)
 
     if world_info.local_rank == 0:
-        logger.setLevel(level=getattr(logging, log_level, logging.INFO))
+        logger.setLevel(level=getattr(logging, config.log_level, logging.INFO))
     else:
-        if get_env_config_bool(config, "log_all_rank", False):
-            logger.setLevel(level=getattr(logging, log_level, logging.INFO))
+        if config.log_all_rank:
+            logger.setLevel(level=getattr(logging, config.log_level, logging.INFO))
         else:
             logger.setLevel(level=logging.CRITICAL)  # Disable logging for non-zero ranks
 

--- a/src/zeroband/utils/metric_logger.py
+++ b/src/zeroband/utils/metric_logger.py
@@ -18,10 +18,8 @@ class WandbMetricLogger(MetricLogger):
 
         import wandb
 
-        run_name = logger_config["config"]["run_name"]
-
         wandb.init(
-            project=project, config=logger_config, name=run_name, resume="auto" if resume else None
+            project=project, config=logger_config, name=logger_config.config.run_name, resume="auto" if resume else None
         )  # make wandb reuse the same run id if possible
 
     def log(self, metrics: dict[str, Any]):

--- a/src/zeroband/utils/metric_logger.py
+++ b/src/zeroband/utils/metric_logger.py
@@ -18,8 +18,9 @@ class WandbMetricLogger(MetricLogger):
 
         import wandb
 
+        print(logger_config["config"])
         wandb.init(
-            project=project, config=logger_config, name=logger_config.config.run_name, resume="auto" if resume else None
+            project=project, config=logger_config, name=logger_config["config"]["run_name"], resume="auto" if resume else None
         )  # make wandb reuse the same run id if possible
 
     def log(self, metrics: dict[str, Any]):

--- a/src/zeroband/utils/metric_logger.py
+++ b/src/zeroband/utils/metric_logger.py
@@ -18,7 +18,6 @@ class WandbMetricLogger(MetricLogger):
 
         import wandb
 
-        print(logger_config["config"])
         wandb.init(
             project=project, config=logger_config, name=logger_config["config"]["run_name"], resume="auto" if resume else None
         )  # make wandb reuse the same run id if possible


### PR DESCRIPTION
Autism wins yet again. This is the last time though.

Instead of resolving the env vars as you access them with get_env_config(), let's just resolve them all at the beginning and do `config.thing`. The env var for that is still `ZERO_BAND_THING`, as before. But now we don't have to replace every place the config is accessed.

Because screw that, honestly. This is way better, and is what it should have been in the first place.