### PR TITLE
match pre commit ruff and uv lock ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.4.4
+  rev: v0.9.3
   hooks:
     # Run the linter.
     - id: ruff


### PR DESCRIPTION
it seems that we are not all running the same ruff version which creates unnecessarily formatting diff in some PR 

![Screenshot from 2025-02-01 13-51-31](https://github.com/user-attachments/assets/c08b0238-484b-4995-9728-ee3033796df8)

this pr lock the uv version I the pre commit to the same version as in our uv.lock