### PR TITLE
docs: fix typo in Hugging Face upload instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,4 +186,4 @@ You can then upload the model to huggingface using huggingface-cli:
 # Usage:  huggingface-cli upload [repo_id] [local_path] [path_in_repo]
 huggingface-cli upload username/mymodel /path/to/save/converted_model . --private
 ```
-The repo will be created if `repo_id` does not exist. The `--private` will create the repo as a private repo and cab ne ommited to create a publicly accessible repo.
+The repo will be created if `repo_id` does not exist. The `--private` will create the repo as a private repo and can be ommited to create a publicly accessible repo.


### PR DESCRIPTION
<img width="957" alt="Снимок экрана 2025-04-10 в 20 51 26" src="https://github.com/user-attachments/assets/a0009342-5e4c-4ae6-b00d-6b5c766e3d50" />
"cab ne ommited" → "can be omitted"