### PR TITLE
Fix export_dcp.py bugs

### DIFF
--- a/scripts/export_dcp.py
+++ b/scripts/export_dcp.py
@@ -135,11 +135,8 @@ def main(config: ExportConfig):
 
     logger.info("Getting model")
     model, model_config = get_model(
-        config.name_model,
-        config.type_model,
-        vocab_size=len(tokenizer),
-        seq_length=config.data.seq_length,
-        attn_fn=config.train.attn_fn,
+        config,
+        len(tokenizer)
     )
 
     # Convert ZeroBand config to HuggingFace config
@@ -162,7 +159,7 @@ def main(config: ExportConfig):
     logger.info("After load: %s", get_module_signature(model))
 
     # Convert model to HuggingFace format
-    num_shards = int(sum(p.numel() for p in model.parameters()) / 1e9)
+    num_shards = max(1, int(sum(p.numel() for p in model.parameters()) / 1e9))
     state_dict = model.state_dict()
 
     index_json = {}


### PR DESCRIPTION
This pull request introduces improvements to the model export process and checkpoint handling. The key updates include simplifying the `get_model` function call, ensuring shard count is at least 1, and enabling the use of `cloudpickle` for saving and loading checkpoint files to enhance serialization flexibility.

### Model Export Improvements:
* Simplified the `get_model` function call by passing the `config` object and tokenizer length directly, reducing the number of parameters. (`scripts/export_dcp.py`, [scripts/export_dcp.pyL138-R139](diffhunk://#diff-dd6f16e669f920da14bed950e8322586557f85352e4f3b0ab9e27c976e4b6165L138-R139))
* Ensured that the number of shards (`num_shards`) is at least 1 to avoid potential zero-shard errors. (`scripts/export_dcp.py`, [scripts/export_dcp.pyL165-R162](diffhunk://#diff-dd6f16e669f920da14bed950e8322586557f85352e4f3b0ab9e27c976e4b6165L165-R162))

### Checkpoint Handling Enhancements:
* Introduced `cloudpickle` as the `pickle_module` for `torch.save` and `torch.load` operations, improving serialization support for complex objects. (`src/zeroband/checkpoint.py`, [[1]](diffhunk://#diff-c13cda86c6471115fa5cf06f2b135422e845b53fb092c5ca211e21eb6b7dbabfR1) [[2]](diffhunk://#diff-c13cda86c6471115fa5cf06f2b135422e845b53fb092c5ca211e21eb6b7dbabfL300-R301) [[3]](diffhunk://#diff-c13cda86c6471115fa5cf06f2b135422e845b53fb092c5ca211e21eb6b7dbabfL323-R324) [[4]](diffhunk://#diff-c13cda86c6471115fa5cf06f2b135422e845b53fb092c5ca211e21eb6b7dbabfL373-R374) [[5]](diffhunk://#diff-c13cda86c6471115fa5cf06f2b135422e845b53fb092c5ca211e21eb6b7dbabfL418-R419)
* Fixed a logging attribute by replacing `self.logger` with `self._logger` in the `delete_topk` call to align with the correct attribute name. (`src/zeroband/checkpoint.py`, [src/zeroband/checkpoint.pyL357-R358](diffhunk://#diff-c13cda86c6471115fa5cf06f2b135422e845b53fb092c5ca211e21eb6b7dbabfL357-R358))