### PR TITLE
Avoid shell invocation in subset downloader

### DIFF
--- a/scripts/subset_data.py
+++ b/scripts/subset_data.py
@@ -55,13 +55,18 @@ def _download_file(data_file: str, save_path: str) -> None:
             logger.debug(f"Creating directory: {parent}")
             os.makedirs(parent, exist_ok=True)
 
-    cmd = [
-        "wget",
-        f'--header="Authorization: Bearer {get_token()}"',
-        f"https://huggingface.co/{data_file}?download=true",
-        f"-O {save_path}",
-    ]
-    result = subprocess.run(" ".join(cmd), shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    cmd = ["wget"]
+    token = get_token()
+    if token is not None:
+        cmd.append(f"--header=Authorization: Bearer {token}")
+    cmd.extend(
+        [
+            f"https://huggingface.co/{data_file}?download=true",
+            "-O",
+            save_path,
+        ]
+    )
+    result = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
     if result.returncode != 0:
         logger.error(f"Error downloading file: {data_file}")
         logger.error(result.stderr.decode("utf-8"))

--- a/src/zeroband/utils/wget.py
+++ b/src/zeroband/utils/wget.py
@@ -1,19 +1,29 @@
+import shutil
 import subprocess
 
-import shutil
 
 def _get_cut_dirs_from_url(url: str) -> int:
     return len(url.rstrip().partition("//")[-1].split("/"))
 
+
 def wget(source: str, destination: str) -> None:
     # logger = get_logger()
-    cmd = f"wget -r -np -nH --cut-dirs={_get_cut_dirs_from_url(source)} -P {destination} {source}"
+    cmd = [
+        "wget",
+        "-r",
+        "-np",
+        "-nH",
+        f"--cut-dirs={_get_cut_dirs_from_url(source)}",
+        "-P",
+        destination,
+        source,
+    ]
 
     if shutil.which("wget") is None:
         raise RuntimeError("wget is required but not found. Please install wget and try again.")
 
     try:
-        subprocess.run(cmd, shell=True, check=True, capture_output=True, text=True)
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
     except subprocess.CalledProcessError as e:
         # logger.error(f"Error output: {e.stderr}")
         print(f"Error output: {e.stderr}")

--- a/tests/test_subset_data_download.py
+++ b/tests/test_subset_data_download.py
@@ -14,6 +14,9 @@ def load_subset_data_module():
     hf_stub = types.ModuleType("huggingface_hub")
     hf_stub.get_token = lambda: None
     sys.modules.setdefault("huggingface_hub", hf_stub)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda iterable, *args, **kwargs: iterable
+    sys.modules.setdefault("tqdm", tqdm_stub)
 
     module_path = Path(__file__).resolve().parents[1] / "scripts" / "subset_data.py"
     spec = importlib.util.spec_from_file_location("subset_data", module_path)

--- a/tests/test_subset_data_download.py
+++ b/tests/test_subset_data_download.py
@@ -1,0 +1,58 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+def load_subset_data_module():
+    datasets_stub = types.ModuleType("datasets")
+    datasets_stub.BuilderConfig = object
+    datasets_stub.load_dataset_builder = lambda *args, **kwargs: None
+    sys.modules.setdefault("datasets", datasets_stub)
+    hf_stub = types.ModuleType("huggingface_hub")
+    hf_stub.get_token = lambda: None
+    sys.modules.setdefault("huggingface_hub", hf_stub)
+
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "subset_data.py"
+    spec = importlib.util.spec_from_file_location("subset_data", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class SubsetDataDownloadTests(unittest.TestCase):
+    def test_download_file_invokes_wget_without_shell(self):
+        module = load_subset_data_module()
+        captured = {}
+
+        class CompletedProcess:
+            returncode = 0
+            stderr = b""
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return CompletedProcess()
+
+        module.get_token = lambda: "hf_test_token"
+        module.subprocess.run = fake_run
+
+        with TemporaryDirectory() as tmpdir:
+            module._download_file(
+                "hf://datasets/PrimeIntellect/fineweb-edu@revision/data/train-000.parquet",
+                str(Path(tmpdir) / "fineweb-edu" / "data" / "train-000.parquet"),
+            )
+
+        self.assertIsInstance(captured["cmd"], list)
+        self.assertEqual(captured["cmd"][0], "wget")
+        self.assertEqual(captured["cmd"][1], "--header=Authorization: Bearer hf_test_token")
+        self.assertEqual(captured["cmd"][-2], "-O")
+        self.assertTrue(captured["cmd"][-1].endswith("fineweb-edu/data/train-000.parquet"))
+        self.assertIsNot(captured["kwargs"].get("shell"), True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wget_util.py
+++ b/tests/test_wget_util.py
@@ -1,0 +1,57 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+def load_wget_module():
+    module_path = Path(__file__).resolve().parents[1] / "src" / "zeroband" / "utils" / "wget.py"
+    spec = importlib.util.spec_from_file_location("zeroband_wget", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class WgetUtilTests(unittest.TestCase):
+    def test_wget_invokes_subprocess_without_shell(self):
+        module = load_wget_module()
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+
+        module.shutil.which = lambda name: "/usr/bin/wget" if name == "wget" else None
+        module.subprocess.run = fake_run
+
+        module.wget(
+            "https://example.com/datasets/model/file.txt;touch /tmp/pwned",
+            "/tmp/download target",
+        )
+
+        self.assertEqual(
+            captured["cmd"],
+            [
+                "wget",
+                "-r",
+                "-np",
+                "-nH",
+                "--cut-dirs=6",
+                "-P",
+                "/tmp/download target",
+                "https://example.com/datasets/model/file.txt;touch /tmp/pwned",
+            ],
+        )
+        self.assertIsNot(captured["kwargs"].get("shell"), True)
+        self.assertTrue(captured["kwargs"]["check"])
+
+    def test_wget_requires_wget_binary(self):
+        module = load_wget_module()
+        module.shutil.which = lambda name: None
+
+        with self.assertRaisesRegex(RuntimeError, "wget is required"):
+            module.wget("https://example.com/file.txt", "/tmp/downloads")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- build dataset `wget` invocations as argument lists instead of shell strings
- build the shared `zeroband.utils.wget()` invocation as an argument list too
- omit the Authorization header when no Hugging Face token is available
- add focused regression tests for both subprocess invocation paths

## Why
The download paths currently joined command strings and used `shell=True`. Dataset file paths, output paths, and utility inputs can be data-derived, so keeping shell interpretation out of these paths avoids accidental command parsing while preserving the same `wget` download flow.

## Verification
- `uv run --no-project --with pytest pytest -q tests/test_subset_data_download.py tests/test_wget_util.py`
- `python3 -m py_compile src/zeroband/utils/wget.py tests/test_subset_data_download.py tests/test_wget_util.py`
- `git diff --check`
